### PR TITLE
Add Node v14 back to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ 16, 18, 20 ]
+        node-version: [ 14, 16, 18, 20 ]
         os: [ windows-latest, ubuntu-latest, macOS-latest ]
 
     steps:


### PR DESCRIPTION
**Why?**

Because, for the moment, Lambda still supports Node 14. So Architect also supports runtime compatibility. Recent `tap-arc` releases have helped restore Node 14 combat, so I'm keeping it in the testing matrix for now to help not release something that will break tests in Arc Land